### PR TITLE
Ensure core services are running after reboot

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -304,7 +304,7 @@ start_firewall() {
 docker_defaults() {
   size=`df -h / | sed -n 2p | awk '{print $2}'`
   cat <<-END
-DOCKER_OPTS="--iptables=false --storage-opt dm.loopdatasize=$size --storage-driver=aufs --storage-opt dm.basesize=$size"
+DOCKER_OPTS="--iptables=false --storage-driver=aufs"
 
 END
 }


### PR DESCRIPTION
Ensure systemd services start on reboot
Enhance systemd configs
Let system load modules
Never oom-kill core services
Redirect stderr to stdout on nanoagent (stacktraces in logs)
Handle file permissions edge case
Use better PS1

Might help with or resolve #11