### PR TITLE
Set CI mode before provider

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -87,8 +87,8 @@ run_as_root "curl \
 run_as_root "chmod +x /usr/local/bin/nanobox"
 
 # 4 - Set nanobox configuration
-run_as_user "nanobox config set provider native"
-
 run_as_user "nanobox config set ci-mode true"
+
+run_as_user "nanobox config set provider native"
 
 echo "Nanobox is ready to go!"


### PR DESCRIPTION
Since running as root is forbidden except in CI mode, we need to do that before any other `nanobox` command can be attempted.