### PR TITLE
Ensure HTTPS Transport is installed

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -47,6 +47,8 @@ if [[ ! -f /usr/bin/docker ]]; then
   which lsb_release || run_as_root "apt-get -y install lsb-release"
 
   release=$(lsb_release -cs)
+  
+  [ -f /usr/lib/apt/methods/https ] || run_as_root "apt-get -y install apt-transport-https"
 
   # add the source to our apt sources
   run_as_root "echo \


### PR DESCRIPTION
The Docker repository uses HTTPS for added security. However, some CIs default to not having the HTTPS transport for APT installed, meaning we need to do it for them.

So let's do it for them. 😊