### PR TITLE
Accept ext_if and int_if as args to bootstrap script

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -574,7 +574,7 @@ END
 }
 
 build_firewall() {
-  cat <<'END'
+  cat <<END
 #!/bin/bash
 
 if [ ! -f /run/iptables ]; then
@@ -608,8 +608,15 @@ if [ ! -f /run/iptables ]; then
   iptables -A INPUT -i docker0 -j ACCEPT
   iptables -A FORWARD -i docker0 -j ACCEPT
   iptables -A FORWARD -o docker0 -j ACCEPT
-  iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-  iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
+  iptables -t nat -A POSTROUTING -o ${INTERNAL_IFACE} -j MASQUERADE
+END
+
+if [ -n $EXTERNAL_IFACE ]
+then
+  echo "  iptables -t nat -A POSTROUTING -o ${EXTERNAL_IFACE} -j MASQUERADE"
+fi
+
+cat <<END
   touch /run/iptables
 fi
 END
@@ -678,6 +685,9 @@ for i in "${@}"; do
       ;;
     internal-iface=* )
       INTERNAL_IFACE=${i#*=}
+      ;;
+    external-iface=* )
+      EXTERNAL_IFACE=${i#*=}
       ;;
   esac
 


### PR DESCRIPTION
We shouldn't be using `eth0` and `eth1` as hard coded values. Odin should tell us which ones the provider expects, instead, and we should use those accordingly. This is already happening for int_if, to be fair, but ext_if is left entirely unaccounted for. This commit adds support for ext_if, and also ensures both interfaces are used correctly in all the configs that are affected by them (including the NAT setup in the iptables config).

Fixes #30 